### PR TITLE
Add coliship product code in shipping methods

### DIFF
--- a/src/Entity/Shipping/ColishipShippingMethodInterface.php
+++ b/src/Entity/Shipping/ColishipShippingMethodInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Coliship plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusColishipPlugin\Entity\Shipping;
+
+interface ColishipShippingMethodInterface
+{
+    public function getColishipProductCode(): ?string;
+
+    public function setColishipProductCode(?string $colishipProductCode): void;
+}

--- a/src/Entity/Shipping/ColishipShippingMethodTrait.php
+++ b/src/Entity/Shipping/ColishipShippingMethodTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Coliship plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusColishipPlugin\Entity\Shipping;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait ColishipShippingMethodTrait
+{
+    /**
+     * @ORM\Column(name="coliship_product_code", type="string", length=10, nullable=true)
+     */
+    protected ?string $colishipProductCode = null;
+
+    /**
+     * @return string|null
+     */
+    public function getColishipProductCode(): ?string
+    {
+        return $this->colishipProductCode;
+    }
+
+    /**
+     * @param string|null $colishipProductCode
+     */
+    public function setColishipProductCode(?string $colishipProductCode): void
+    {
+        $this->colishipProductCode = $colishipProductCode;
+    }
+}

--- a/src/Form/Extension/Shipping/ShippingMethodTypeExtension.php
+++ b/src/Form/Extension/Shipping/ShippingMethodTypeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Coliship plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusColishipPlugin\Form\Extension\Shipping;
+
+use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ShippingMethodTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('colishipProductCode', TextType::class, [
+                'label' => 'monsieurbiz_coliship.form.shipping_method.coliship_product_code',
+                'help' => 'monsieurbiz_coliship.form.shipping_method.coliship_product_code_help',
+                'required' => false,
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ShippingMethodType::class];
+    }
+}

--- a/src/Mapping/FmtMapping.php
+++ b/src/Mapping/FmtMapping.php
@@ -76,13 +76,15 @@ final class FmtMapping implements MappingInterface
             'ServiceDestinataire' => function(OrderInterface $order) {
                 return $order->getShippingAddress()->getService();
             },
-            'CodeProduit' => function() {
-                return 'COLD';
+            'CodeProduit' => function(OrderInterface $order) {
+                $shipment = $order->getShipments()->first();
+
+                return $shipment ? $shipment->getMethod()->getColishipProductCode() ?? 'COLD' : 'COLD';
             },
             'Poids' => function(OrderInterface $order) {
                 //@TODO get current shipment only
                 return $order->getShipments()->first()->getShippingWeight();
-            }
+            },
         ];
     }
 

--- a/src/Resources/config/sylius/ui.yaml
+++ b/src/Resources/config/sylius/ui.yaml
@@ -3,3 +3,11 @@ sylius_ui:
         monsieurbiz.coliship.settings.admin.update.actions:
             blocks:
                 buttons: '@MonsieurBizSyliusColishipPlugin/Admin/Settings/Actions/_buttons.html.twig'
+
+        sylius.admin.shipping_method.update.form:
+            blocks:
+                _form: '@MonsieurBizSyliusColishipPlugin/Admin/ShippingMethod/Edit/_form.html.twig'
+
+        sylius.admin.shipping_method.create.form:
+            blocks:
+                _form: '@MonsieurBizSyliusColishipPlugin/Admin/ShippingMethod/Create/_form.html.twig'

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -15,6 +15,8 @@ monsieurbiz_coliship:
                 download_fmt: Download the FMT file
         settings:
             method_code_deprecated: 'Method code (Deprecated, use Method Codes instead)'
+            shipping_method:
+                header: 'Coliship configuration for Shipping Method'
     form:
         address:
             service: Service
@@ -25,3 +27,6 @@ monsieurbiz_coliship:
             doorCode2: Door code 2
             intercom: Intercom
             shippingInstructions: Delivery instructions
+        shipping_method:
+            coliship_product_code: Coliship Product Code
+            coliship_product_code_help: The value designates the product offer of the package to be created according to its delivery characteristics (range, destination, delivery method). For example, "COLD" for home delivery without signature, "COL" for home delivery with signature etc.

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -15,6 +15,8 @@ monsieurbiz_coliship:
                 download_fmt: Télécharger le fichier FMT
         settings:
             method_code_deprecated: 'Method code (Déprécié, utiliser Method Codes)'
+            shipping_method:
+                header: 'Paramètres Coliship du mode de livraison'
     form:
         address:
             service: Service
@@ -25,3 +27,6 @@ monsieurbiz_coliship:
             doorCode2: Code porte 2
             intercom: Interphone
             shippingInstructions: Instructions de livraison
+        shipping_method:
+            coliship_product_code: Code Produit Coliship
+            coliship_product_code_help: La valeur désigne l'offre produit du colis à créer selon ses caractéristiques de livraison (gamme, destination, mode de livraison). Par exemple, "COLD" pour du domicile sans signatue, "COL" pour du domicile avec signature etc.

--- a/src/Resources/views/Admin/ShippingMethod/Create/_form.html.twig
+++ b/src/Resources/views/Admin/ShippingMethod/Create/_form.html.twig
@@ -1,0 +1,1 @@
+{% extends '@MonsieurBizSyliusColishipPlugin/Admin/ShippingMethod/Edit/_form.html.twig' %}

--- a/src/Resources/views/Admin/ShippingMethod/Edit/_form.html.twig
+++ b/src/Resources/views/Admin/ShippingMethod/Edit/_form.html.twig
@@ -1,0 +1,3 @@
+<h4 class="ui dividing header">{{ 'monsieurbiz_coliship.admin.ui.shipping_method.header'|trans }}</h4>
+
+{{ form_row(form.colishipProductCode) }}

--- a/tests/Application/config/bootstrap.php
+++ b/tests/Application/config/bootstrap.php
@@ -29,4 +29,4 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -27,3 +27,9 @@ sylius_addressing:
         address:
             classes:
                 model: App\Entity\Addressing\Address
+
+sylius_shipping:
+    resources:
+        shipping_method:
+            classes:
+                model: App\Entity\Shipping\ShippingMethod

--- a/tests/Application/src/Entity/Shipping/ShippingMethod.php
+++ b/tests/Application/src/Entity/Shipping/ShippingMethod.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Coliship plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Entity\Shipping;
+
+use Doctrine\ORM\Mapping as ORM;
+use MonsieurBiz\SyliusColishipPlugin\Entity\Shipping\ColishipShippingMethodInterface;
+use MonsieurBiz\SyliusColishipPlugin\Entity\Shipping\ColishipShippingMethodTrait;
+use Sylius\Component\Core\Model\ShippingMethod as BaseShippingMethod;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="sylius_shipping_method")
+ */
+class ShippingMethod extends BaseShippingMethod implements ColishipShippingMethodInterface
+{
+    use ColishipShippingMethodTrait;
+}


### PR DESCRIPTION
Be able to set a Coliship Product Code on Shipping Method form : 

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/11380627/126172236-156bbe88-e6be-4584-a5f2-1c30dfd29305.png">

This one will be use if it's set during the export.
If not, the old default value `COLD` still be returned.