### PR TITLE
Add locale in export file

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,9 @@ jobs:
       - name: Composer Github Auth
         run: composer config -g github-oauth.github.com ${{ github.token }}
 
+      - name: Composer allow plugins
+        run: composer config -g allow-plugins true
+
       - run: make install
 
       - run: make test.composer

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ${APP_DIR}/node_modules: yarn.install
 application: .php-version php.ini ${APP_DIR} setup_application ${APP_DIR}/docker-compose.yaml
 
 ${APP_DIR}:
-	(${COMPOSER} create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="${SYLIUS_VERSION}" ${APP_DIR})
+	(${COMPOSER} create-project --no-interaction --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard="${SYLIUS_VERSION}" ${APP_DIR})
 
 setup_application:
 	rm -f ${APP_DIR}/yarn.lock
@@ -73,7 +73,8 @@ setup_application:
 	$(MAKE) apply_dist
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
-	(cd ${APP_DIR} && ${COMPOSER} install)
+	cd ${APP_DIR} && ${COMPOSER} install --no-interaction
+	cd ${APP_DIR} && ${COMPOSER} symfony:recipes:install --no-interaction
 
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml

--- a/composer.json
+++ b/composer.json
@@ -72,5 +72,13 @@
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "symfony/thanks": true,
+            "ergebnis/composer-normalize": true,
+            "symfony/flex": true
+        }
     }
 }

--- a/src/Controller/Admin/ExportController.php
+++ b/src/Controller/Admin/ExportController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusColishipPlugin\Controller\Admin;
 
 use MonsieurBiz\SyliusColishipPlugin\Exporter\ExporterInterface;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 final class ExportController extends AbstractController
 {
     public function exportAction(
+        SettingsInterface $colishipSettings,
         ChannelRepositoryInterface $channelRepository,
         ExporterInterface $colishipExporter,
         string $channelCode
@@ -29,6 +31,10 @@ final class ExportController extends AbstractController
             throw $this->createNotFoundException('Channel not found');
         }
 
+        $locale = $colishipSettings->getCurrentValue($channel, null, 'exportLocale');
+        if (!empty($locale)) {
+            setlocale(\LC_CTYPE, $locale);
+        }
         $file = $colishipExporter->exportToFile($channel);
 
         return new StreamedResponse(

--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -19,6 +19,7 @@ use MonsieurBiz\SyliusSettingsPlugin\Form\SettingsTypeInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -94,6 +95,10 @@ class SettingsType extends AbstractSettingsType implements SettingsTypeInterface
                 'required' => false,
                 'multiple' => true,
                 'choices' => $this->fmtDirectory->getValues(),
+            ])
+            ->addWithDefaultCheckbox($builder, 'exportLocale', TextType::class, [
+                'required' => false,
+                'label' => 'monsieurbiz_coliship.admin.settings.export_locale',
             ])
         ;
     }

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -13,11 +13,11 @@ monsieurbiz_coliship:
             actions:
                 export: Coliship Export
                 download_fmt: Download the FMT file
+            shipping_method:
+                header: 'Coliship configuration for Shipping Method'
         settings:
             export_locale: 'Locale used to convert the export file'
             method_code_deprecated: 'Method code (Deprecated, use Method Codes instead)'
-            shipping_method:
-                header: 'Coliship configuration for Shipping Method'
     form:
         address:
             service: Service

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -14,6 +14,7 @@ monsieurbiz_coliship:
                 export: Coliship Export
                 download_fmt: Download the FMT file
         settings:
+            export_locale: 'Locale used to convert the export file'
             method_code_deprecated: 'Method code (Deprecated, use Method Codes instead)'
             shipping_method:
                 header: 'Coliship configuration for Shipping Method'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -14,6 +14,7 @@ monsieurbiz_coliship:
                 export: Export Coliship
                 download_fmt: Télécharger le fichier FMT
         settings:
+            export_locale: 'Locale à utiliser dans le fichier d''export'
             method_code_deprecated: 'Method code (Déprécié, utiliser Method Codes)'
             shipping_method:
                 header: 'Paramètres Coliship du mode de livraison'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -13,11 +13,11 @@ monsieurbiz_coliship:
             actions:
                 export: Export Coliship
                 download_fmt: Télécharger le fichier FMT
+            shipping_method:
+                header: 'Paramètres Coliship du mode de livraison'
         settings:
             export_locale: 'Locale à utiliser dans le fichier d''export'
             method_code_deprecated: 'Method code (Déprécié, utiliser Method Codes)'
-            shipping_method:
-                header: 'Paramètres Coliship du mode de livraison'
     form:
         address:
             service: Service


### PR DESCRIPTION
## Issue

Sometimes the `iconv` methods does not work properly do to the lack of locale when exporting a Coliship file.

```
 Notice: iconv(): Detected an illegal character in input string in /var/www/apps/sylius/vendor/monsieurbiz/sylius-coliship-plugin/src/Controller/Admin/ExportController.php on line 39
```

So we had the possibility to set it in settings.

### Translation correction

Also correct a translation in the shipping method edit header : 

![image](https://user-images.githubusercontent.com/11380627/161556031-26cf57f0-876d-4079-b298-6a6358264db8.png)
