### PR TITLE
Allow Sylius 1.11

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -9,6 +9,8 @@ jobs:
 
   recipe:
 
+    name: "Recipe (PHP ${{ matrix.php }}, Sylius ${{ matrix.sylius }})"
+
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: Setup some requirements
         working-directory: ./sylius
         run: |
+            composer config --no-plugins allow-plugins true
             composer config repositories.plugin '{"type": "path", "url": "../plugin/"}'
             composer config extra.symfony.allow-contrib true
             composer config secure-http false

--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -19,13 +19,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4' ,'8.0']
-        sylius: ["~1.8.0", "~1.9.0", "~1.10.0"]
+        php: ["7.4" ,"8.0"]
+        sylius: ["~1.8.0", "~1.9.0", "~1.10.0", "~1.11.0"]
         exclude:
-          - php: 8.0
+          - php: "8.0"
             sylius: "~1.8.0"
-          - php: 8.0
+          - php: "8.0"
             sylius: "~1.9.0"
+          - php: "7.4"
+            sylius: "~1.11.0"
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -47,4 +47,4 @@ jobs:
       - name: Install PHP dependencies
         run: composer update --prefer-dist
 
-      - uses: symfonycorp/security-checker-action@v2
+      - uses: symfonycorp/security-checker-action@v3

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,6 +8,8 @@ jobs:
 
   security:
 
+    name: "Security (PHP ${{ matrix.php }})"
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0']
+        php: ['8.0']
 
     env:
       SYMFONY_ARGS: --no-tls

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install symfony CLI
         run: |
-          curl https://get.symfony.com/cli/installer | bash
-          echo "${HOME}/.symfony/bin" >> $GITHUB_PATH
+          curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
+          sudo apt install symfony-cli
 
       - uses: actions/cache@v1
         id: cache-composer

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,8 @@ jobs:
 
   php:
 
+    name: "Tests (PHP ${{ matrix.php }})"
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=1.10.0
+SYLIUS_VERSION=1.11.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "~7.4|~8.0",
         "ext-mbstring": "*",
-        "sylius/sylius": ">=1.8 <1.11",
+        "sylius/sylius": ">=1.8 <1.12",
         "monsieurbiz/sylius-settings-plugin": "^1.0.0"
     },
     "require-dev": {
@@ -75,7 +75,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "symfony/thanks": true,
             "ergebnis/composer-normalize": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "phpstan/extension-installer": true
         }
     }
 }


### PR DESCRIPTION
- Drop PHP 7.4 in Tests, since we are using Sylius 1.11
- Allow all composer plugins during Recipe workflows in GHA
- Update symfony cli related steps in GHA
- Let's go for Sylius 1.11 🔥
- Add a name to each test in github actions